### PR TITLE
Update readme file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           --debug
         python -m build .
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1.5
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
         skip_existing: true

--- a/README.md
+++ b/README.md
@@ -1,39 +1,40 @@
-# A sample Python project
+# Changelog2version
 
-![Python Logo](https://www.python.org/static/community_logos/python-logo.png "Sample inline image")
+[![Downloads](https://pepy.tech/badge/changelog2version)](https://pepy.tech/project/changelog2version)
+![Release](https://img.shields.io/github/v/release/brainelectronics/changelog2version?include_prereleases&color=success)
+![Python](https://img.shields.io/badge/python3-Ok-green.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A sample project that exists as an aid to the [Python Packaging User
-Guide][packaging guide]'s [Tutorial on Packaging and Distributing
-Projects][distribution tutorial].
+Update version info file with latest changelog version entry
 
-This project does not aim to cover best practices for Python project
-development as a whole. For example, it does not provide guidance or tool
-recommendations for version control, documentation, or testing.
+---------------
 
-[The source for this project is available here][src].
+## General
 
-Most of the configuration for a Python project is done in the `setup.py` file,
-an example of which is included in this project. You should edit this file
-accordingly to adapt this sample project to your needs.
+Create version info files based on the latest changelog entry.
 
-----
+## Installation
 
-This is the README file for the project.
+```bash
+pip install changelog2version
+```
 
-The file should use UTF-8 encoding and can be written using
-[reStructuredText][rst] or [markdown][md use] with the appropriate [key set][md
-use]. It will be used to generate the project webpage on PyPI and will be
-displayed as the project homepage on common code-hosting services, and should be
-written for that purpose.
+## Usage
 
-Typical contents for this file would include an overview of the project, basic
-usage examples, etc. Generally, including the project changelog in here is not a
-good idea, although a simple “What's New” section for the most recent version
-may be appropriate.
+This example shows you how to parse the [repo's changelog](changelog.md) and
+update the [package version file](src/changelog2version/version.py) with that
+version.
 
-[packaging guide]: https://packaging.python.org
-[distribution tutorial]: https://packaging.python.org/tutorials/packaging-projects/
-[src]: https://github.com/pypa/sampleproject
-[rst]: http://docutils.sourceforge.net/rst.html
-[md]: https://tools.ietf.org/html/rfc7764#section-3.5 "CommonMark variant"
-[md use]: https://packaging.python.org/specifications/core-metadata/#description-content-type-optional
+```bash
+changelog2version \
+    --changelog_file changelog.md \
+    --version_file src/changelog2version/version.py \
+    --debug
+```
+
+## Credits
+
+Based on the [PyPa sample project][ref-pypa-sample].
+
+<!-- Links -->
+[ref-pypa-sample]: https://github.com/pypa/sampleproject

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,12 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.1.1] - 2022-07-31
+### Fixed
+- Update root [`README`](README.md) file with usage instructions
+- Use `0.0.0` as default in the checked in
+  [package version file](src/changelog2version/version.py)
+
 ## [0.1.0] - 2022-07-31
 ### Added
 - This changelog file
@@ -31,7 +37,6 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - [`.gitignore`](.gitignore) file after fork to latest
   [Python gitignore template][ref-python-gitignore-template]
 - [`setup.py`](setup.py) file after fork
-- [`README`](README.md) file with usage instructions
 - [`tox.ini`](tox.ini) file after fork to use `nose2` and create coverage
   report
 - [GitHub CI release workflow](.github/workflows/release.yml) updated to run
@@ -46,8 +51,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Data folder after fork
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.1.0...develop
+[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.1.1...develop
 
+[0.1.1]: https://github.com/brainelectronics/changelog2version/tree/0.1.1
 [0.1.0]: https://github.com/brainelectronics/changelog2version/tree/0.1.0
 
 <!--

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,8 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Update root [`README`](README.md) file with usage instructions
 - Use `0.0.0` as default in the checked in
   [package version file](src/changelog2version/version.py)
+- Use `release/v1.5` branch of `pypa/gh-action-pypi-publish` in the
+  [GitHub CI release workflow](.github/workflows/release.yml) file
 
 ## [0.1.0] - 2022-07-31
 ### Added

--- a/src/changelog2version/version.py
+++ b/src/changelog2version/version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-__version_info__ = ('0', '1', '0')
+__version_info__ = ('0', '0', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'


### PR DESCRIPTION
### Fixed
- Update root [`README`](README.md) file with usage instructions
- Use `0.0.0` as default in the checked in [package version file](src/changelog2version/version.py)
- Use `release/v1.5` branch of `pypa/gh-action-pypi-publish` in the [GitHub CI release workflow](.github/workflows/release.yml) file
