### PR TITLE
Support additional version data in python version file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,7 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,7 +21,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.9'
-    - name: Install build dependencies
+    - name: Install build and deploy dependencies
       run: |
         python -m pip install -U setuptools wheel build
         if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -29,7 +29,7 @@ jobs:
           --changelog_file changelog.md \
           --version_file src/changelog2version/version.py \
           --version_file_type py \
-          --additional_version_info "-rc{github.run_attempt}"
+          --additional_version_info "-rc${{github.run_attempt}}"
           --debug
         python -m build .
         echo "Attempt: ${{ github.run_attempt }}"

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -29,7 +29,7 @@ jobs:
           --changelog_file changelog.md \
           --version_file src/changelog2version/version.py \
           --version_file_type py \
-          --additional_version_info="-rc${{github.run_number}}" \
+          --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \
           --debug
         python -m build .
     - name: Test built package

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -29,7 +29,7 @@ jobs:
           --changelog_file changelog.md \
           --version_file src/changelog2version/version.py \
           --version_file_type py \
-          --additional_version_info="-rc${{github.run_attempt}}" \
+          --additional_version_info="-rc${{github.run_number}}" \
           --debug
         python -m build .
         echo "Attempt: ${{ github.run_attempt }}"

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -29,7 +29,7 @@ jobs:
           --changelog_file changelog.md \
           --version_file src/changelog2version/version.py \
           --version_file_type py \
-          --additional_version_info "-rc${{github.run_attempt}}"
+          --additional_version_info="-rc${{github.run_attempt}}" \
           --debug
         python -m build .
         echo "Attempt: ${{ github.run_attempt }}"

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1.5
       with:
-        repository_url: https://test.pypi.org/legacy/
+        repository_url: https://test.pypi.org/
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         skip_existing: true
         verbose: true

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,56 @@
+# this file is *not* meant to cover or endorse the use of GitHub Actions, but rather to
+# help make automated releases for this project
+
+name: Upload Python Package to test.pypi.org
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9'
+    - name: Install deploy dependencies
+      run: |
+        python -m pip install -U setuptools wheel build
+        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+        pip install .
+    - name: Build package
+      run: |
+        changelog2version \
+          --changelog_file changelog.md \
+          --version_file src/changelog2version/version.py \
+          --version_file_type py \
+          --additional_version_info "-rc{github.run_attempt}"
+          --debug
+        python -m build .
+        echo "Attempt: ${{ github.run_attempt }}"
+        echo "Number: ${{ github.run_number }}"
+        echo "ID: ${{ github.run_id }}"
+    - name: Test built package
+      run: |
+        twine check dist/*.tar.gz
+    - name: Archive build package artifact
+      uses: actions/upload-artifact@v3
+      with:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+        # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
+        name: dist_py.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
+        path: dist/*.tar.gz
+        retention-days: 14
+    # - name: Publish package
+    #   uses: pypa/gh-action-pypi-publish@release/v1.5
+    #   with:
+    #     repository_url: https://test.pypi.org/legacy/
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    #     skip_existing: true
+    #     verbose: true
+    #     print_hash: true

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1.5
       with:
-        repository_url: https://test.pypi.org/
+        repository_url: https://test.pypi.org/legacy/
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         skip_existing: true
         verbose: true

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -32,9 +32,6 @@ jobs:
           --additional_version_info="-rc${{github.run_number}}" \
           --debug
         python -m build .
-        echo "Attempt: ${{ github.run_attempt }}"
-        echo "Number: ${{ github.run_number }}"
-        echo "ID: ${{ github.run_id }}"
     - name: Test built package
       run: |
         twine check dist/*.tar.gz
@@ -46,11 +43,11 @@ jobs:
         name: dist_py.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
         path: dist/*.tar.gz
         retention-days: 14
-    # - name: Publish package
-    #   uses: pypa/gh-action-pypi-publish@release/v1.5
-    #   with:
-    #     repository_url: https://test.pypi.org/legacy/
-    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-    #     skip_existing: true
-    #     verbose: true
-    #     print_hash: true
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1.5
+      with:
+        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        skip_existing: true
+        verbose: true
+        print_hash: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,12 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     # runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         # os: [ubuntu-latest, macos-latest, windows-latest]
-
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -55,12 +53,3 @@ jobs:
     - name: Test built package
       run: |
         twine check dist/*.tar.gz
-    - name: Archive build package artifact
-      uses: actions/upload-artifact@v3
-      if: ${{ matrix.python-version == '3.9' }}
-      with:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-        # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
-        name: dist_py.${{ matrix.python-version }}_repo.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
-        path: dist/*.tar.gz
-        retention-days: 14

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Create version info files based on the latest changelog entry.
 - [Advanced](#advanced)
     - [Custom regular expressions](#custom-regular-expressions)
     - [Custom template file](#custom-template-file)
+    - [Additional version info content](#additional-version-info-content)
 - [Credits](#credits)
 
 <!-- /MarkdownTOC -->
@@ -173,6 +174,34 @@ Creation datetime: 2022-08-05T21:11:12
 Created by Death Star
 ```
 
+### Additional version info content
+
+To create custom release candidate packages the python version file variable
+`__version__` can be exended with a custom string.
+
+Choose the additional version info content carefully as not everything is
+supported by PyPi, see the
+[Python Core metadata specifications][ref-py-core-metadata-spec] and
+[PEP440][ref-pep440]
+
+```bash
+changelog2version \
+    --changelog_file changelog.md \
+    --version_file examples/version.py \
+    --version_file_type py \
+    --additional_version_info="rc1234" \
+    --debug
+```
+
+```
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+__version_info__ = ("0", "5", "0")
+__version__ = '.'.join(__version_info__) + '-rc1234'
+
+```
+
 ## Credits
 
 Based on the [PyPa sample project][ref-pypa-sample]. Also a big thank you to
@@ -182,6 +211,8 @@ documentation and [regex example][ref-semver-regex-example]
 <!-- Links -->
 [ref-package-version-file]: src/changelog2version/version.py
 [ref-templates-folder]: src/changelog2version/templates
+[ref-py-core-metadata-spec]: https://packaging.python.org/specifications/core-metadat
+[ref-pep440]: https://peps.python.org/pep-0440/
 [ref-pypa-sample]: https://github.com/pypa/sampleproject
 [ref-semver]: https://semver.org/
 [ref-semver-regex-example]: https://regex101.com/r/Ly7O1x/3/

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,16 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.5.0] - 2022-10-20
+### Added
+- Support additional version info file content in python version files by
+  adding the content given by `--additional_version_info="-rc1234"` to the
+  end of the constructed `__version__` content.
+  This will create the following line in a `version.py` file:
+  `__version__ = '.'.join(__version_info__) + '-rc1234'`
+  A created package will thereby be named `0.5.0rc1234` if the version is
+  `0.5.0`, resolve [#14][ref-issue-14]
+
 ## [0.4.0] - 2022-08-07
 ### Added
 - Property `semver_data` to access extracted VersionInfo from parsed semver
@@ -118,8 +128,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Data folder after fork
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.4.0...develop
+[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.5.0...develop
 
+[0.5.0]: https://github.com/brainelectronics/changelog2version/tree/0.5.0
 [0.4.0]: https://github.com/brainelectronics/changelog2version/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/changelog2version/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/changelog2version/tree/0.2.0
@@ -130,6 +141,7 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 [ref-issue-8]: https://github.com/brainelectronics/changelog2version/issues/8
 [ref-issue-11]: https://github.com/brainelectronics/changelog2version/issues/11
 [ref-issue-4]: https://github.com/brainelectronics/changelog2version/issues/4
+[ref-issue-14]: https://github.com/brainelectronics/changelog2version/issues/14
 
 [ref-codecov-changelog2version]: https://app.codecov.io/github/brainelectronics/changelog2version
 [ref-python-gitignore-template]: https://github.com/github/gitignore/blob/e5323759e387ba347a9d50f8b0ddd16502eb71d4/Python.gitignore

--- a/src/changelog2version/templates/version.py.template
+++ b/src/changelog2version/templates/version.py.template
@@ -2,4 +2,4 @@
 # -*- coding: UTF-8 -*-
 
 __version_info__ = ("{{ major_version }}", "{{ minor_version }}", "{{ patch_version }}")
-__version__ = '.'.join(__version_info__)
+__version__ = '.'.join(__version_info__){{ additional_data }}

--- a/src/changelog2version/update_version.py
+++ b/src/changelog2version/update_version.py
@@ -114,6 +114,12 @@ def parse_arguments() -> argparse.Namespace:
                         type=json.loads,
                         help='Additional data as JSON to render the template')
 
+    parser.add_argument('--additional_version_info',
+                        dest='additional_version_info',
+                        required=False,
+                        type=str,
+                        help='Additional version informations like "-rc1234"')
+
     parser.add_argument('--version_line_regex',
                         dest='version_line_regex',
                         required=False,
@@ -152,6 +158,7 @@ def main():
     template_file = args.template_file
     version_file_type = args.version_file_type
     additional_template_data = args.additional_template_data
+    additional_version_info = args.additional_version_info
     version_line_regex = args.version_line_regex
     semver_line_regex = args.semver_line_regex
 
@@ -175,12 +182,16 @@ def main():
 
     file_renderer = RenderVersionFile()
     semver_data = version_extractor.semver_data
+    additional_data = ""
+    if additional_version_info:
+        additional_data = " + '{}'".format(additional_version_info)
     version_file_content = {
         "major_version": semver_data.major,
         "minor_version": semver_data.minor,
         "patch_version": semver_data.patch,
         "prerelease_data": semver_data.prerelease,
-        "build_data": semver_data.build
+        "build_data": semver_data.build,
+        "additional_data": additional_data,
     }
     if additional_template_data:
         version_file_content.update(additional_template_data)


### PR DESCRIPTION
### Added
- Support additional version info file content in python version files by adding the content given by `--additional_version_info="-rc1234"` to the end of the constructed `__version__` content. This will create the following line in a `version.py` file: `__version__ = '.'.join(__version_info__) + '-rc1234'`. A created package will thereby be named `0.5.0rc1234` if the version is `0.5.0`, resolve #14 
