### PR TITLE
Parse changelog and create prerelease with tag on every PR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -26,6 +26,15 @@ jobs:
         python -m pip install -U setuptools wheel build
         if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
         pip install .
+    - name: Parse changelog
+      id: parse_changelog
+      run: |
+        changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+        echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
+        cat latest_description.txt >> $GITHUB_OUTPUT
+        echo '"EOT"' >> $GITHUB_OUTPUT
+        latest_version=$(changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+        echo "latest_version=$latest_version" >> $GITHUB_ENV
     - name: Build package
       run: |
         changelog2version \
@@ -41,3 +50,13 @@ jobs:
         skip_existing: true
         verbose: true
         print_hash: true
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.latest_version }}
+        release_name: ${{ env.latest_version }}
+        body: ${{ steps.parse_changelog.outputs.LATEST_DESCRIPTION }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -6,7 +6,7 @@ name: Upload Python Package to test.pypi.org
 on: [pull_request]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test-deploy:
@@ -23,6 +23,15 @@ jobs:
         python -m pip install -U setuptools wheel build
         if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
         pip install .
+    - name: Parse changelog
+      id: parse_changelog
+      run: |
+        changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+        echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
+        cat latest_description.txt >> $GITHUB_OUTPUT
+        echo '"EOT"' >> $GITHUB_OUTPUT
+        latest_version=$(changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+        echo "latest_version=$latest_version" >> $GITHUB_ENV
     - name: Build package
       run: |
         changelog2version \
@@ -51,3 +60,13 @@ jobs:
         skip_existing: true
         verbose: true
         print_hash: true
+    - name: Create Prerelease
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.latest_version }}-rc${{ github.run_number }}.dev${{ github.event.number }}
+        release_name: ${{ env.latest_version }}-rc${{ github.run_number }}.dev${{ github.event.number }}
+        body: ${{ steps.parse_changelog.outputs.LATEST_DESCRIPTION }}
+        draft: false
+        prerelease: true

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.8.0] - 2022-11-11
+### Added
+- Create release candidate tag and release on every pull request build. The release description is the latest changelog content, the release title is the latest changelog version. The release is marked as pre-release, see #18
+
 ## [0.7.0] - 2022-11-11
 ### Added
 - Changelog parsed as JSON contains a new key `description` like the PyPi package JSON info, compare to `https://pypi.org/pypi/changelog2version/json`, with the description/content of the latest change, see #19, relates to #18
@@ -149,8 +153,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Data folder after fork
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.7.0...main
+[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.8.0...main
 
+[0.8.0]: https://github.com/brainelectronics/changelog2version/tree/0.8.0
 [0.7.0]: https://github.com/brainelectronics/changelog2version/tree/0.7.0
 [0.6.0]: https://github.com/brainelectronics/changelog2version/tree/0.6.0
 [0.5.0]: https://github.com/brainelectronics/changelog2version/tree/0.5.0


### PR DESCRIPTION
### Added
- Create release candidate tag and release on every pull request build. The release description is the latest changelog content, the release title is the latest changelog version. The release is marked as pre-release, see #18