### PR TITLE
Extend args with verbosity and version options

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,31 @@ changelog2version \
 ```
 
 ```json
-{"info": {"version": "0.6.0"}, "releases": {"0.6.0": [{"upload_time": "2022-10-26"}], "0.5.0": [{"upload_time": "2022-10-20"}], "0.4.0": [{"upload_time": "2022-08-07"}], "0.3.0": [{"upload_time": "2022-08-05"}], "0.2.0": [{"upload_time": "2022-08-03"}], "0.1.1": [{"upload_time": "2022-07-31"}], "0.1.0": [{"upload_time": "2022-07-31"}]}}
+{"info": {"version": "0.7.0", "description": "### Added\n- Changelog parsed as JSON contains a new key `description` like the PyPi package JSON info, compare to `https://pypi.org/pypi/changelog2version/json`, with the description/content of the latest change, see #19, relates to #18\n- Increase unittest coverage above 95%\n\n### Changed\n- Line breaks are no longer used in this changelog for enumerations\n- Issues are referenced as `#123` instead of `[#123][ref-issue-123]` to avoid explicit references at the bottom or some other location in the file\n- Output of `changelog2version` call with `--print` but without `--debug` option is JSON compatible\n"}, "releases": {"0.7.0": [{"upload_time": "2022-11-11"}], "0.6.0": [{"upload_time": "2022-10-26"}], "0.5.0": [{"upload_time": "2022-10-20"}], "0.4.0": [{"upload_time": "2022-08-07"}], "0.3.0": [{"upload_time": "2022-08-05"}], "0.2.0": [{"upload_time": "2022-08-03"}], "0.1.1": [{"upload_time": "2022-07-31"}], "0.1.0": [{"upload_time": "2022-07-31"}]}}
+```
+
+To get the latest version and description in the console as environment
+variables use the following call
+
+```bash
+LATEST_VERSION=$(changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+LATEST_CHANGE=$(changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])")
+
+echo "The latest version extracted from the changelog is ${LATEST_VERSION}"
+# The latest version extracted from the changelog is 0.7.0
+
+echo "Description of the latest change"
+echo "${LATEST_CHANGE}"
+# ### Added
+# - Changelog parsed as JSON contains a new key `description` like the PyPi package JSON info, compare to `https://pyp
+# i.org/pypi/changelog2version/json`, with the description/content of the latest change, see #19, relates to #18
+# - Increase unittest coverage above 95%
+
+# ### Changed
+# - Line breaks are no longer used in this changelog for enumerations
+# - Issues are referenced as `#123` instead of `[#123][ref-issue-123]` to avoid explicit references at the bottom or s
+# ome other location in the file
+# - Output of `changelog2version` call with `--print` but without `--debug` option is JSON compatible
 ```
 
 ##### File

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,12 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.9.0] - 2022-11-12
+### Added
+- Version of `changelog2version` can be requested with `--version` argument, see #22
+- Verbosity of internal logger can be set with `-vvvv` as `DEBUG`, default level is `CRITICAL`, see #22
+- Usage example in README for description and version extraction from JSON in console, introduced in 0.7.0, see #20
+
 ## [0.8.0] - 2022-11-11
 ### Added
 - Create release candidate tag and release on every pull request build. The release description is the latest changelog content, the release title is the latest changelog version. The release is marked as pre-release, see #18
@@ -153,8 +159,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Data folder after fork
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.8.0...main
+[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.9.0...main
 
+[0.9.0]: https://github.com/brainelectronics/changelog2version/tree/0.9.0
 [0.8.0]: https://github.com/brainelectronics/changelog2version/tree/0.8.0
 [0.7.0]: https://github.com/brainelectronics/changelog2version/tree/0.7.0
 [0.6.0]: https://github.com/brainelectronics/changelog2version/tree/0.6.0

--- a/src/changelog2version/update_version.py
+++ b/src/changelog2version/update_version.py
@@ -81,6 +81,11 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('-d', '--debug',
                         action='store_true',
                         help='Output logger messages to stderr')
+    parser.add_argument('-v',
+                        default=0,
+                        action='count',
+                        dest='verbosity',
+                        help='Set level of verbosity, default is CRITICAL')
 
     # specific arguments
     parser.add_argument('--changelog_file',
@@ -159,14 +164,22 @@ def main():
     # parse CLI arguments
     args = parse_arguments()
 
+    log_levels = {
+        0: logging.CRITICAL,
+        1: logging.ERROR,
+        2: logging.WARNING,
+        3: logging.INFO,
+        4: logging.DEBUG,
+    }
     custom_format = '[%(asctime)s] [%(levelname)-8s] [%(filename)-15s @'\
                     ' %(funcName)-15s:%(lineno)4s] %(message)s'
     logging.basicConfig(level=logging.INFO,
                         format=custom_format,
                         stream=stdout)
     logger = logging.getLogger(__name__)
-    if args.debug:
-        logger.setLevel(logging.DEBUG)
+    logger.setLevel(level=log_levels[min(args.verbosity,
+                                     max(log_levels.keys()))])
+    logger.disabled = not args.debug
 
     # changelog_file = Path(args.changelog_file).resolve()
     changelog_file = args.changelog_file

--- a/src/changelog2version/update_version.py
+++ b/src/changelog2version/update_version.py
@@ -30,6 +30,7 @@ from sys import stdout
 
 from .extract_version import ExtractVersion
 from .render_version_file import RenderVersionFile
+from .version import __version__
 
 
 def parser_valid_file(parser: argparse.ArgumentParser, arg: str) -> Path:
@@ -86,6 +87,11 @@ def parse_arguments() -> argparse.Namespace:
                         action='count',
                         dest='verbosity',
                         help='Set level of verbosity, default is CRITICAL')
+    parser.add_argument('--version',
+                        action='version',
+                        version='%(prog)s {version}'.
+                                format(version=__version__),
+                        help="Print version of package and exit")
 
     # specific arguments
     parser.add_argument('--changelog_file',


### PR DESCRIPTION
### Added
- Version of `changelog2version` can be requested with `--version` argument, see #22
- Verbosity of internal logger can be set with `-vvvv` as `DEBUG`, default level is `CRITICAL`, see #22
- Usage example in README for description and version extraction from JSON in console, introduced in 0.7.0, see #20