### PR TITLE
Add validation command line option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+---
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+        args: ["--markdown-linebreak-ext=md"]
+      - id: check-yaml
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+---
+
+- id: changelog2version
+  name: changelog2version
+  description: Validate version file against latest changelog entry
+  entry: changelog2version
+  language: python
+  pass_filenames: false
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Create version info files based on the latest changelog entry.
         - [JSON output](#json-output)
             - [Console](#console)
             - [File](#file)
+    - [Validate generated file](#validate-generated-file)
 - [Advanced](#advanced)
     - [Custom regular expressions](#custom-regular-expressions)
     - [Custom template file](#custom-template-file)
@@ -163,6 +164,35 @@ changelog2version \
 ```
 
 See [example JSON file][ref-example-json-file]
+
+### Validate generated file
+
+To validate an already generated version file agains the latest available
+changelog the `--validate` option can be used.
+
+The following command will exit with a non-zero code in case of a difference
+between the generated version file (`examples/version.py`) and the latest
+changelog content.
+
+```bash
+changelog2version \
+    --changelog_file changelog.md \
+    --version_file examples/version.py \
+    --validate \
+    --debug
+```
+
+By default a Python version file is assumed, for a C header version file the
+call has to be extended with the `version_file_type` option
+
+```bash
+changelog2version \
+    --changelog_file changelog.md \
+    --version_file examples/version_info.h \
+    --version_file_type c \
+    --validate \
+    --debug
+```
 
 ## Advanced
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,13 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.10.0] - 2023-07-08
+### Added
+- `--validate` argument can be used to validate an existing version file against the latest changelog entry
+-  `RenderVersionFile` provides a `content` property with the rendered file content after calling the `render_file` function
+- `save_file` parameter of `render_file` function can be used to only render, but not save content to file
+- pre-commit hook and config files
+
 ## [0.9.0] - 2022-11-12
 ### Added
 - Version of `changelog2version` can be requested with `--version` argument, see #22
@@ -159,8 +166,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Data folder after fork
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.9.0...main
+[Unreleased]: https://github.com/brainelectronics/changelog2version/compare/0.10.0...main
 
+[0.10.0]: https://github.com/brainelectronics/changelog2version/tree/0.10.0
 [0.9.0]: https://github.com/brainelectronics/changelog2version/tree/0.9.0
 [0.8.0]: https://github.com/brainelectronics/changelog2version/tree/0.8.0
 [0.7.0]: https://github.com/brainelectronics/changelog2version/tree/0.7.0

--- a/src/changelog2version/render_version_file.py
+++ b/src/changelog2version/render_version_file.py
@@ -35,6 +35,7 @@ class RenderVersionFile(object):
 
         self._env = None
         self._default_template_path = Path(__file__).parent / "templates"
+        self._content = ""
 
     @property
     def default_template_path(self) -> Path:
@@ -64,6 +65,16 @@ class RenderVersionFile(object):
         else:
             raise RenderVersionFileError(
                 "Specified directory '{}' doesn't exist".format(template_path))
+
+    @property
+    def content(self) -> str:
+        """
+        Get rendered version file content
+
+        :returns:   Rendered version file content
+        :rtype:     str
+        """
+        return self._content
 
     def _find_file(self, template: Union[Path, str]) -> Path:
         """
@@ -116,7 +127,8 @@ class RenderVersionFile(object):
     def render_file(self,
                     file_path: Path,
                     content: dict,
-                    template: Union[Path, str]) -> None:
+                    template: Union[Path, str],
+                    save_file: bool = True) -> None:
         """
         Render a template file with given content
 
@@ -126,6 +138,8 @@ class RenderVersionFile(object):
         :type       content:    dict
         :param      template:   The path to the template file
         :type       template:   Union[Path, str]
+        :param      save_file:  Save rendered content to file
+        :type       save_file:  bool
         """
         template_file = self._find_file(template=template)
 
@@ -136,6 +150,10 @@ class RenderVersionFile(object):
 
         file_template = self._env.get_template(template_file.name)
         rendered_content = file_template.render(content)
+        self._content = rendered_content
+
+        if not save_file:
+            return
 
         Path(file_path.parent).mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
### Added
- `--validate` argument can be used to validate an existing version file against the latest changelog entry
-  `RenderVersionFile` provides a `content` property with the rendered file content after calling the `render_file` function
- `save_file` parameter of `render_file` function can be used to only render, but not save content to file
- pre-commit hook and config files