### PR TITLE
Use snippets2changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install build and deploy dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
           python -m pip install -U setuptools wheel build
           if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
           pip install .
+      - name: Update changelog with snippets
+        run: |
+          changelog-generator \
+            changelog changelog.md \
+            --snippets=.snippets \
+            --in-place
       - name: Parse changelog
         id: parse_changelog
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # all history is needed to crawl it properly
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install deploy dependencies

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -24,6 +24,12 @@ jobs:
           python -m pip install -U setuptools wheel build
           if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
           pip install .
+      - name: Update changelog with snippets
+        run: |
+          changelog-generator \
+            changelog changelog.md \
+            --snippets=.snippets \
+            --in-place
       - name: Parse changelog
         id: parse_changelog
         run: |

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # all history is needed to crawl it properly
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
           python -m pip install -U setuptools wheel build
           if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
           pip install .
+      - name: Update changelog with snippets
+        run: |
+          changelog-generator \
+            changelog changelog.md \
+            --snippets=.snippets \
+            --in-place
       - name: Build package
         run: |
           changelog2version \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # all history is needed to crawl it properly
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
         # os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           # python-version: '3.9'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     # runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         # os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -13,8 +13,8 @@ jobs:
   test-and-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Execute tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ examples/*.c
 examples/*.h
 examples/*.py
 examples/version_info
+changelog.json
 
 # custom, package specific ignores
 .DS_Store

--- a/.snippets/26.md
+++ b/.snippets/26.md
@@ -1,0 +1,12 @@
+## Use snippets2changelog
+<!--
+type: feature
+scope: all
+affected: all
+-->
+
+- run isort on all files
+- drop Python 3.8 support everywhere and update README badge
+- add generated `changelog.json` file to `.gitignore`
+- use latest `actions/checkout@v4` and `actions/setup-python@v5`
+- use `snippets2changelog` package, closes #26

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Downloads](https://pepy.tech/badge/changelog2version)](https://pepy.tech/project/changelog2version)
 ![Release](https://img.shields.io/github/v/release/brainelectronics/changelog2version?include_prereleases&color=success)
-![Python](https://img.shields.io/badge/python3-Ok-green.svg)
+![Python](https://img.shields.io/badge/Python-3.9%20|%203.10%20|%203.11-green.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/github/brainelectronics/changelog2version/branch/main/graph/badge.svg)](https://app.codecov.io/github/brainelectronics/changelog2version)
 

--- a/create_report_dirs.py
+++ b/create_report_dirs.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Create test report directories."""
-from pathlib import Path
 import os
 import shutil
+from pathlib import Path
 
 if os.path.exists('reports'):
     shutil.rmtree('reports', ignore_errors=True)

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -2,3 +2,4 @@
 # Avoid fixed versions
 # # to upload package to PyPi or other package hosts
 twine>=5.1.1,<6
+snippets2changelog>=1.2.1,<2

--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,6 @@ setup(
         # that you indicate you support Python 3. These classifiers are *not*
         # checked by 'pip install'. See instead 'python_requires' below.
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/src/changelog2version/extract_version.py
+++ b/src/changelog2version/extract_version.py
@@ -7,11 +7,12 @@ from this line
 """
 
 import logging
-from pathlib import Path
 import re
-from semver import VersionInfo
+from pathlib import Path
 from sys import stdout
 from typing import List, Optional
+
+from semver import VersionInfo
 
 
 class ExtractVersionError(Exception):

--- a/src/changelog2version/render_version_file.py
+++ b/src/changelog2version/render_version_file.py
@@ -3,10 +3,11 @@
 
 """Render version file based on template"""
 
-from jinja2 import Environment, FileSystemLoader
 import logging
 from pathlib import Path
 from typing import Optional, Union
+
+from jinja2 import Environment, FileSystemLoader
 
 from .extract_version import ExtractVersion
 

--- a/src/changelog2version/update_version.py
+++ b/src/changelog2version/update_version.py
@@ -21,13 +21,14 @@ The semantic version tag inside the square brackets supports the full scope.
 
 import argparse
 import fileinput
-from hashlib import sha1
 import json
 import logging
-from pathlib import Path
 import re
-import semver
+from hashlib import sha1
+from pathlib import Path
 from sys import stdout
+
+import semver
 
 from .extract_version import ExtractVersion
 from .render_version_file import RenderVersionFile

--- a/tests/test_extract_version.py
+++ b/tests/test_extract_version.py
@@ -3,16 +3,16 @@
 """Unittest for testing the extract_version file"""
 
 import logging
-from nose2.tools import params
+import unittest
 from pathlib import Path
-from semver import VersionInfo
 from sys import stdout
 from typing import List
-import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
-from changelog2version.extract_version import ExtractVersion, \
-    ExtractVersionError
+from changelog2version.extract_version import (ExtractVersion,
+                                               ExtractVersionError)
+from nose2.tools import params
+from semver import VersionInfo
 
 
 class TestExtractVersion(unittest.TestCase):

--- a/tests/test_update_version.py
+++ b/tests/test_update_version.py
@@ -3,9 +3,9 @@
 """Unittest for testing the update_version file"""
 
 import logging
+import unittest
 from pathlib import Path
 from sys import stdout
-import unittest
 
 
 class TestUpdateVersion(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 #  and also to help confirm pull requests to this project.
 
 [tox]
-envlist = py{37,38,39,310}
+envlist = py{39,310,311}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and


### PR DESCRIPTION
- run isort on all files
- drop Python 3.8 support everywhere and update README badge
- add generated `changelog.json` file to `.gitignore`
- use latest `actions/checkout@v4` and `actions/setup-python@v5`
- use `snippets2changelog` package, closes #26